### PR TITLE
Record inertia PUT / PATCH / DELETE requests

### DIFF
--- a/src/Recorders/ValidationErrors.php
+++ b/src/Recorders/ValidationErrors.php
@@ -112,7 +112,7 @@ class ValidationErrors
     {
         if (
             ! $request->hasSession() ||
-            ! ($response->getStatusCode() !== 302 && $response->getStatusCode() !== 303) ||
+            ! in_array($response->getStatusCode(), [302, 303]) ||
             ! ($errors = $request->session()->get('errors', null)) instanceof ViewErrorBag
         ) {
             return null;

--- a/src/Recorders/ValidationErrors.php
+++ b/src/Recorders/ValidationErrors.php
@@ -111,8 +111,8 @@ class ValidationErrors
     protected function parseSessionValidationErrors(Request $request, SymfonyResponse $response): ?Collection
     {
         if (
-            $response->getStatusCode() !== 302 ||
             ! $request->hasSession() ||
+            ! ($response->getStatusCode() !== 302 && $response->getStatusCode() !== 303) ||
             ! ($errors = $request->session()->get('errors', null)) instanceof ViewErrorBag
         ) {
             return null;

--- a/tests/RecorderTest.php
+++ b/tests/RecorderTest.php
@@ -345,7 +345,7 @@ it('captures inertia validation non post errors', function () {
         'email' => 'required',
     ]))->middleware(['web', InertiaMiddleware::class]);
 
-    $response = put('users', [], ['X-Inertia' => '1']);
+    $response = put('settings', [], ['X-Inertia' => '1']);
 
     $response->assertStatus(303);
     $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->whereType('validation_error')->get());

--- a/tests/RecorderTest.php
+++ b/tests/RecorderTest.php
@@ -17,6 +17,7 @@ use TiMacDonald\Pulse\Recorders\ValidationErrors;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\postJson;
+use function Pest\Laravel\put;
 
 beforeEach(function () {
     Config::set('pulse.ingest.trim.lottery', [1, 1]);
@@ -334,6 +335,24 @@ it('captures inertia validation errors', function () {
     expect($entries[0]->key)->toBe('["POST","\/users","Closure","default","email"]');
     $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->whereType('validation_error')->orderBy('period')->get());
     expect($aggregates->pluck('key')->all())->toBe(array_fill(0, 4, '["POST","\/users","Closure","default","email"]'));
+    expect($aggregates->pluck('aggregate')->all())->toBe(array_fill(0, 4, 'count'));
+    expect($aggregates->pluck('value')->every(fn ($value) => $value == 1.0))->toBe(true);
+});
+
+it('captures inertia validation non post errors', function () {
+    Config::set('pulse.recorders.'.ValidationErrors::class.'.capture_messages', false);
+    Route::put('settings', fn () => Request::validate([
+        'email' => 'required',
+    ]))->middleware(['web', InertiaMiddleware::class]);
+
+    $response = put('users', [], ['X-Inertia' => '1']);
+
+    $response->assertStatus(303);
+    $entries = Pulse::ignore(fn () => DB::table('pulse_entries')->whereType('validation_error')->get());
+    expect($entries)->toHaveCount(1);
+    expect($entries[0]->key)->toBe('["PUT","\/settings","Closure","default","email"]');
+    $aggregates = Pulse::ignore(fn () => DB::table('pulse_aggregates')->whereType('validation_error')->orderBy('period')->get());
+    expect($aggregates->pluck('key')->all())->toBe(array_fill(0, 4, '["PUT","\/settings","Closure","default","email"]'));
     expect($aggregates->pluck('aggregate')->all())->toBe(array_fill(0, 4, 'count'));
     expect($aggregates->pluck('value')->every(fn ($value) => $value == 1.0))->toBe(true);
 });


### PR DESCRIPTION
Great package! 

Fixing a small paper cut. 

When Inertia makes a PUT/PATCH/DELETE request it [uses a 303 response code](https://github.com/inertiajs/inertia-laravel/blob/1.x/src/Middleware.php#L104), which means any validation errors on these types of requests are ignored. 